### PR TITLE
reduce ram and gc overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Table of Contents
 	* [Test 1](#test-1)
 	* [Test 4](#test-4)
 
+## Local Modifications
+
+This fork of pudge improves the efficiency of deletions for databases with
+large numbers of keys. It also provides a compaction API call to remove
+deleted keys and values, and also 'orphaned' entries in the value file that
+are no longer used.
+
 ## Description
 
 Package pudge is a fast and simple key/value store written using Go's standard library.

--- a/api.go
+++ b/api.go
@@ -397,7 +397,6 @@ func (db *Db) KeysByPrefix(prefix []byte, limit, offset int, asc bool) ([][]byte
 	}
 
 	start, end := checkInterval(found, limit, offset, 0, len(db.keys), asc)
-
 	if start < 0 || start >= len(db.keys) {
 		return arr, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/recoilme/pudge
+module github.com/cosnicolaou/pudge
 
 go 1.13

--- a/pudge.go
+++ b/pudge.go
@@ -150,15 +150,13 @@ func newDb(f string, cfg *Config) (*Db, error) {
 				}
 			}
 			db.vals[strkey] = cmd
-
 		case 1:
 			delete(db.vals, strkey)
 			deletions[strkey] = struct{}{}
 		}
 	}
-
 	if len(deletions) > 0 {
-		nkeys := make([][]byte, len(db.keys)-len(deletions))
+		nkeys := make([][]byte, 0, len(db.keys)-len(deletions))
 		db.sort()
 		for _, key := range db.keys {
 			if _, ok := deletions[string(key)]; !ok {

--- a/pudge.go
+++ b/pudge.go
@@ -139,11 +139,18 @@ func newDb(f string, cfg *Config) (*Db, error) {
 		case 0:
 			if _, exists := db.vals[strkey]; !exists {
 				//write new key at keys store
-				db.appendKey(key)
+				// in case a deleted key was added back.
+				if _, deleted := deletions[strkey]; deleted {
+					delete(deletions, strkey)
+				} else {
+					// only add the key if it has not been deleted, this
+					// avoids appending the same key multiple times if it
+					// has been added, deleted and then added again.
+					db.appendKey(key)
+				}
 			}
 			db.vals[strkey] = cmd
-			// in case a deleted key was added back.
-			delete(deletions, strkey)
+
 		case 1:
 			delete(db.vals, strkey)
 			deletions[strkey] = struct{}{}


### PR DESCRIPTION
This PR reduces the amount of ram and related GC overhead when loading the database by avoiding conversions to/from []byte and string.